### PR TITLE
Update lodash to 4.17.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git@github.com:CoursePark/NestHydrationJS.git"
   },
   "dependencies": {
-    "lodash": "4.13.1"
+    "lodash": "4.17.5"
   },
   "devDependencies": {
     "coveralls": "2.11.9",


### PR DESCRIPTION
Lodash before 4.17.5 has a security issue that allows the prototype to be polluted.

See: https://snyk.io/vuln/npm:lodash:20180130